### PR TITLE
Add Linux ARM64 support

### DIFF
--- a/.github/workflows/build-libs.yml
+++ b/.github/workflows/build-libs.yml
@@ -102,10 +102,34 @@ jobs:
           name: libcurve25519_dalek-macos-arm64
           path: lib/solace/utils/macos-arm64/libcurve25519_dalek.dylib
 
+  build-linux-arm64:
+    name: Build on Linux ARM64
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: aarch64-unknown-linux-gnu
+
+      - name: Build Linux ARM64 shared lib
+        run: |
+          cargo build --manifest-path=ext/curve25519_dalek/Cargo.toml --release --target=aarch64-unknown-linux-gnu
+          mkdir -p lib/solace/utils/linux-arm64
+          cp ext/curve25519_dalek/target/aarch64-unknown-linux-gnu/release/libcurve25519_dalek.so lib/solace/utils/linux-arm64/
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: libcurve25519_dalek-linux-arm64
+          path: lib/solace/utils/linux-arm64/libcurve25519_dalek.so
+
   commit-artifacts:
     name: Commit built binaries
     runs-on: ubuntu-latest
-    needs: [build-linux, build-windows, build-macos, build-macos-arm64]
+    needs: [build-linux, build-windows, build-macos, build-macos-arm64, build-linux-arm64]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/Rakefile
+++ b/Rakefile
@@ -33,6 +33,12 @@ PLATFORMS = {
     ext: 'dylib',
     rustlib: 'libcurve25519_dalek.dylib',
     path: 'lib/solace/utils/libcurve25519_dalek-macos-arm64/libcurve25519_dalek.dylib'
+  },
+  linux_arm64: {
+    target: 'aarch64-unknown-linux-gnu',
+    ext: 'so',
+    rustlib: 'libcurve25519_dalek.so',
+    path: 'lib/solace/utils/libcurve25519_dalek-linux-arm64/libcurve25519_dalek.so'
   }
 }.freeze
 

--- a/lib/solace/utils/curve25519_dalek.rb
+++ b/lib/solace/utils/curve25519_dalek.rb
@@ -24,7 +24,12 @@ module Solace
       # @return [String] The path to the native library
       # @raise [RuntimeError] If the platform is not supported
       libfile = case RUBY_PLATFORM
-                when /linux/ then 'libcurve25519_dalek-linux/libcurve25519_dalek.so'
+                when /linux/
+                  if RUBY_PLATFORM =~ /arm|aarch64/
+                    'libcurve25519_dalek-linux-arm64/libcurve25519_dalek.so'
+                  else
+                    'libcurve25519_dalek-linux/libcurve25519_dalek.so'
+                  end
                 when /darwin/
                   if RUBY_PLATFORM =~ /arm64|aarch64/
                     'libcurve25519_dalek-macos-arm64/libcurve25519_dalek.dylib'


### PR DESCRIPTION
## Summary

Adds support for Linux ARM64 (aarch64) - useful for AWS Graviton, Raspberry Pi, and other ARM-based Linux systems.

## Changes

- **Rakefile**: Add `linux_arm64` platform target (`aarch64-unknown-linux-gnu`)
- **lib/solace/utils/curve25519_dalek.rb**: Update platform detection to check for ARM on Linux
- **.github/workflows/build-libs.yml**: Add `build-linux-arm64` job using `ubuntu-24.04-arm` runner

## Test plan

- [x] Verified platform detection logic handles Linux ARM64 case
- [x] macOS tests still pass (269 runs, 0 failures)
- [x] Linux ARM64 binary to be built by CI workflow after merge

🤖 Generated with [Claude Code](https://claude.ai/code)