### PR TITLE
Add error class hierarchy for rescue-friendly error handling

### DIFF
--- a/lib/solace/errors.rb
+++ b/lib/solace/errors.rb
@@ -5,6 +5,8 @@ module Solace
   #
   # These exceptions provide specific error handling for various failure scenarios
   # when interacting with the Solana blockchain, including:
+  # - {Solace::Errors::Error} - Base class for all Solace errors
+  # - {Solace::Errors::ConnectionError} - Base class for connection-related errors
   # - {Solace::Errors::HTTPError} - HTTP communication failures
   # - {Solace::Errors::RPCError} - RPC method errors returned by the node
   # - {Solace::Errors::ParseError} - Data parsing and deserialization errors
@@ -13,7 +15,8 @@ module Solace
   # @see Solace::Connection
   # @since 0.0.8
   module Errors
-    # JSON-RPC Errors
+    require 'solace/errors/error'
+    require 'solace/errors/connection_error'
     require 'solace/errors/rpc_error'
     require 'solace/errors/http_error'
     require 'solace/errors/parse_error'

--- a/lib/solace/errors/confirmation_timeout.rb
+++ b/lib/solace/errors/confirmation_timeout.rb
@@ -17,7 +17,7 @@ module Solace
     #   end
     #
     # @since 0.0.1
-    class ConfirmationTimeout < StandardError
+    class ConfirmationTimeout < Error
       attr_reader :signature, :commitment, :timeout
 
       # @param [String] message The error message

--- a/lib/solace/errors/connection_error.rb
+++ b/lib/solace/errors/connection_error.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Solace
+  module Errors
+    # Base error class for connection-related failures.
+    #
+    # Both {Solace::Errors::HTTPError} and {Solace::Errors::RPCError} inherit
+    # from this class, allowing consumers to rescue all connection errors with
+    # a single clause:
+    #
+    # @example Rescuing all connection errors
+    #   begin
+    #     connection.send_transaction(transaction)
+    #   rescue Solace::Errors::ConnectionError => e
+    #     puts "Connection error: #{e.message}"
+    #   end
+    #
+    # @see Solace::Errors::HTTPError
+    # @see Solace::Errors::RPCError
+    # @since 0.1.0
+    class ConnectionError < Error; end
+  end
+end

--- a/lib/solace/errors/connection_error.rb
+++ b/lib/solace/errors/connection_error.rb
@@ -17,7 +17,7 @@ module Solace
     #
     # @see Solace::Errors::HTTPError
     # @see Solace::Errors::RPCError
-    # @since 0.1.0
+    # @since 0.1.4
     class ConnectionError < Error; end
   end
 end

--- a/lib/solace/errors/error.rb
+++ b/lib/solace/errors/error.rb
@@ -14,7 +14,7 @@ module Solace
     #     puts "Solace error: #{e.message}"
     #   end
     #
-    # @since 0.1.0
+    # @since 0.1.4
     class Error < StandardError; end
   end
 end

--- a/lib/solace/errors/error.rb
+++ b/lib/solace/errors/error.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Solace
+  module Errors
+    # Base error class for all Solace errors.
+    #
+    # All Solace-specific exceptions inherit from this class, allowing consumers
+    # to rescue all Solace errors with a single clause:
+    #
+    # @example Rescuing all Solace errors
+    #   begin
+    #     connection.get_account_info(address)
+    #   rescue Solace::Errors::Error => e
+    #     puts "Solace error: #{e.message}"
+    #   end
+    #
+    # @since 0.1.0
+    class Error < StandardError; end
+  end
+end

--- a/lib/solace/errors/http_error.rb
+++ b/lib/solace/errors/http_error.rb
@@ -18,7 +18,7 @@ module Solace
     #
     # @see Solace::Errors::RPCError
     # @since 0.0.1
-    class HTTPError < StandardError
+    class HTTPError < ConnectionError
       attr_reader :code, :body
 
       # @param [String] message The error message

--- a/lib/solace/errors/parse_error.rb
+++ b/lib/solace/errors/parse_error.rb
@@ -17,7 +17,7 @@ module Solace
     #   end
     #
     # @since 0.0.1
-    class ParseError < StandardError
+    class ParseError < Error
       attr_reader :body
 
       # @param [String] message The error message

--- a/lib/solace/errors/rpc_error.rb
+++ b/lib/solace/errors/rpc_error.rb
@@ -19,7 +19,7 @@ module Solace
     #
     # @see Solace::Errors::HTTPError
     # @since 0.0.1
-    class RPCError < StandardError
+    class RPCError < ConnectionError
       attr_reader :rpc_code, :rpc_message, :rpc_data
 
       # @param [String] message The error message


### PR DESCRIPTION
## Summary
- Introduces `Solace::Errors::Error` as the base class for all Solace errors, allowing consumers to `rescue Solace::Errors::Error` to catch any Solace exception
- Adds `Solace::Errors::ConnectionError` as a shared parent for `HTTPError` and `RPCError`, enabling `rescue Solace::Errors::ConnectionError` for all connection-related failures
- All existing error classes (`HTTPError`, `RPCError`, `ParseError`, `ConfirmationTimeout`) now inherit from the appropriate base instead of `StandardError` directly

## Test plan
- [x] Verified inheritance chain loads correctly via `ruby -I lib` smoke test
- [ ] Run full test suite (`bundle exec rake test`) to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)