### PR TITLE
Fix console.rb load path and update Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,12 @@
 
 source 'https://rubygems.org'
 
+# Build tools
+gem 'rake'
+
 # Minitest
 gem 'factory_bot'
-gem 'minitest'
+gem 'minitest', '~> 5.0'
 gem 'minitest-hooks'
 
 # Local gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    solace (0.1.2)
+    solace (0.1.3)
       base58 (~> 0.2)
       ffi (~> 1.15)
       rbnacl (~> 7.0)
@@ -49,16 +49,17 @@ GEM
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
-    minitest (5.25.5)
-    minitest-hooks (1.5.2)
+    minitest (5.27.0)
+    minitest-hooks (1.5.3)
       minitest (> 5.3)
     parallel (1.27.0)
     parser (3.3.9.0)
       ast (~> 2.4.1)
       racc
-    prism (1.4.0)
+    prism (1.9.0)
     racc (1.8.1)
     rainbow (3.1.1)
+    rake (13.4.2)
     rbnacl (7.1.2)
       ffi (~> 1)
     redcarpet (3.6.1)
@@ -92,7 +93,7 @@ GEM
       concurrent-ruby (~> 1.0)
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
-    unicode-emoji (4.0.4)
+    unicode-emoji (4.2.0)
     uri (1.0.3)
     yard (0.9.37)
     yardstick (0.9.9)
@@ -113,8 +114,9 @@ PLATFORMS
 
 DEPENDENCIES
   factory_bot
-  minitest
+  minitest (~> 5.0)
   minitest-hooks
+  rake
   redcarpet
   rubocop
   rubocop-yard

--- a/console.rb
+++ b/console.rb
@@ -2,8 +2,8 @@
 
 require 'irb'
 
-# Autoload all Ruby files in utils and other directories as needed
-require_relative 'lib/solace'
+$LOAD_PATH.unshift(File.expand_path('lib', __dir__))
+require 'solace'
 
 require 'minitest/autorun'
 require 'minitest/hooks/default'


### PR DESCRIPTION
## Summary
- Fix `console.rb` to add `lib` to `$LOAD_PATH` before requiring solace, matching how `test/bootstrap.rb` does it. This fixes `LoadError` when running `ruby console.rb`.
- Add `rake` gem and pin `minitest ~> 5.0` in Gemfile.

## Test plan
- [ ] Run `ruby console.rb` — should launch IRB without `LoadError`
- [ ] Run `bundle exec rake test` — tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)