### PR TITLE
Bump version to 0.1.4 for ARM64 native binary release

### DIFF
--- a/lib/solace/version.rb
+++ b/lib/solace/version.rb
@@ -2,5 +2,5 @@
 
 module Solace
   # Latest version of the Solace gem.
-  VERSION = '0.1.3'
+  VERSION = '0.1.4'
 end

--- a/solace.gemspec
+++ b/solace.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'solace'
-  spec.version       = '0.1.3'
+  spec.version       = '0.1.4'
   spec.authors       = ['Sebastian Scholl']
   spec.email         = ['sebscholl@gmail.com']
   spec.summary       = 'Solana ruby library'


### PR DESCRIPTION
## Summary
- Bumps gem version from 0.1.3 to 0.1.4 in `solace.gemspec` and `lib/solace/version.rb`
- Published gem 0.1.3 predates the ARM64 support commits and is missing the `libcurve25519_dalek-linux-arm64/` and `libcurve25519_dalek-macos-arm64/` native binaries, as well as the ARM64 platform detection logic in `curve25519_dalek.rb`
- This causes `Bundler::GemRequireError` on ARM64 CI runners (e.g. GitHub Actions `aarch64-linux-gnu`)

## Test plan
- [ ] `gem build solace.gemspec` produces `solace-0.1.4.gem`
- [ ] Inspect gem contents include `libcurve25519_dalek-linux-arm64/` and `libcurve25519_dalek-macos-arm64/` directories
- [ ] `gem push solace-0.1.4.gem` to RubyGems after merge
- [ ] Verify ARM64 CI runner loads the gem successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)